### PR TITLE
always terminate in diff

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -34,6 +34,8 @@ function diffArray(l, r, path='/') {
   const lris = {};
   const rlis = {};
 
+  const adds = [];
+
   for (let i = 0; i < l.length; i++) {
     for (let j = 0; j < r.length; j++) {
       if (j in rlis) continue;
@@ -69,23 +71,29 @@ function diffArray(l, r, path='/') {
     }
 
     if (j < r.length && !(j in rlis)) {
-      ops.push(_op('add', _path(path, j, l[i]), { value: r[j] }));
+      adds.unshift(_op('add', _path(path, j, r[j + 1]), { value: r[j] }));
       j++;
       continue;
     }
 
     if (j < r.length && j in rlis) {
-      ops.push({ op: 'move', from: _path(path, rlis[j], l[rlis[j]]), path: _path(path, j) });
-      if (_typeof(rlis[j]) == 'object') {
-        ops.push(...diffObject(l[rlis[j]], r[j], path));
+      const from = _path(path, rlis[j], l[rlis[j]]);
+      const to = _path(path, j);
+      if (to != from) {
+        ops.push({ op: 'move', from, path: to });
+        if (_typeof(rlis[j]) == 'object') {
+          ops.push(...diffObject(l[rlis[j]], r[j], path));
+        }
       }
-      if (i <= j) i++;
+      i++;
       j++;
       continue;
     }
+
+    throw new Error(`couldn't create diff`);
   }
 
-  return ops;
+  return ops.concat(adds);
 }
 
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -135,6 +135,16 @@ suite('diff', test => {
     );
   })
 
+  test('array of objects append', async () => {
+    assert.deepEqual(
+      diff(
+        [ { id: 1 }, { id: 2 } ],
+        [ { id: 1 }, { id: 2 }, { id: 3 } ]
+      ),
+      [ { op: 'add', path: '/2', value: { id: 3 } } ]
+    );
+  })
+
   test('null to obj', async () => {
     assert.deepEqual(
       diff(
@@ -180,6 +190,65 @@ suite('diff', test => {
       ]
     );
   })
+
+  test('array remove and re-order', async () => {
+    assert.deepEqual(
+      diff(
+        [ { id: 1, name: 'one' }, { id: 2, name: 'two' }, { id: 3, name: 'three' } ],
+        [ { id: 3, name: 'three' }, { id: 2, name: 'two' } ]
+      ),
+      [
+        { op: 'remove', path: '/[1]', _prev: { id: 1, name: 'one' } },
+        { op: 'move', from: '/[3]', path: '/0' },
+        { op: 'move', from: '/[2]', path: '/1' },
+      ]
+    );
+  })
+
+  test('more array remove and re-order', async () => {
+    assert.deepEqual(
+      diff(
+        [ { id: 1, name: 'one' }, { id: 2, name: 'two' }, { id: 3, name: 'three' }, { id: 4, name: 'four' }, { id: 5, name: 'five' } ],
+        [ { id: 3, name: 'three' }, { id: 2, name: 'two' }, { id: 5, name: 'five' } ],
+      ),
+      [
+        { op: 'remove', path: '/[1]', _prev: { id: 1, name: 'one' } },
+        { op: 'move', from: '/[3]', path: '/0' },
+        { op: 'move', from: '/[2]', path: '/1' },
+        { op: 'remove', path: '/[4]', _prev: { id: 4, name: 'four' } },
+      ]
+    );
+  })
+
+  test('array remove and re-order literal', async () => {
+    assert.deepEqual(
+      diff(
+        [ 'abc', 'def', 'hij' ],
+        [ 'hij', 'def' ],
+      ),
+      [
+        { op: 'remove', path: '/0', _prev: 'abc' },
+        { op: 'move', from: '/2', path: '/0' },
+      ]
+    );
+  })
+
+  test('array remove and re-order literal longer', async () => {
+    assert.deepEqual(
+      diff(
+        [ 'abc', 'def', '000', 'hij', 'klm', 'nop' ],
+        [ 'hij', 'nop', 'def', '000', 'klm' ],
+      ),
+      [
+        { _prev: 'abc', op: 'remove', path: '/0' },
+        { from: '/3', op: 'move', path: '/0' },
+        { from: '/5', op: 'move', path: '/1' },
+        { from: '/1', op: 'move', path: '/2' },
+        { from: '/2', op: 'move', path: '/3' }
+      ]
+    );
+  })
+
 
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ require('./patch');
 require('./reverse');
 require('./auto');
 require('./diff');
+require('./roundtrip');
 require('./helpers');
 require('./roundtrip');
 

--- a/test/roundtrip.js
+++ b/test/roundtrip.js
@@ -2,29 +2,98 @@ const suite = require('./index');
 const assert = require('assert');
 const patch = require('../patch');
 const diff = require('../diff');
-const helpers  = require('../helpers');
+const helpers = require('../helpers');
+
+function random() {
+  random._s = random._s || 11224; // seed
+  return (random._s = random._s * 16807 % 2147483647) / 2147483646;
+}
 
 suite('roundtrip', async test => {
 
-  helpers._configure({ strict: false });
 
   test('array truncate', async () => {
+    helpers._configure({ strict: false });
     const initial = [ { email: 'doug@example.com' }, { email: 'jen@example.com' }, { email: 'abhi@example.com' }, { email: 'amber@example.com' } ];
     const target = [ { email: 'doug@example.com' }, { email: 'jen@example.com' } ];
     const changes = diff(initial, target);
     const adjusted = patch(initial, changes);
     assert.deepEqual(adjusted, target);
+    helpers._configure({ strict: true });
   });
 
   test('back populating object ids', async () => {
+    helpers._configure({ strict: false });
     const initial = [{ email: 'doug@example.com' }, { email: 'jen@example.com' }];
     const target = [{ email: 'doug@example.com', id: 1 }, { email: 'jen@example.com', id: 2 }];
     const changes = diff(initial, target);
     const adjusted = patch(initial, changes);
     assert.deepEqual(adjusted, target);
+    helpers._configure({ strict: true });
   })
 
-  helpers._configure({ strict: true });
+  test('array of objects insert', async () => {
+    const initial = [ { id: 1 }, { id: 2 } ];
+    const target = [ { id: 1 }, { id: 3 }, { id: 2 } ];
+
+    const changes = diff(initial, target);
+    const adjusted = patch(initial, changes);
+
+    assert.deepEqual(adjusted, target);
+  })
+
+  test('array remove and reorder', async () => {
+    const initial = [{ id: 1, name: 'one' }, { id: 2, name: 'two' }, { id: 3, name: 'three' }];
+    const target = [{ id: 3, name: 'three' }, { id: 2, name: 'two' }];
+    const changes = diff(initial, target);
+    const adjusted = patch(initial, changes);
+    assert.deepEqual(adjusted, target);
+  })
+
+  test('array remove and reorder no ids', async () => {
+    helpers._configure({ strict: false });
+    const initial = [{ name: 'one' }, { name: 'two' }, { name: 'three' }];
+    const target = [{ name: 'three' }, { name: 'two' }];
+    const changes = diff(initial, target);
+    const adjusted = patch(initial, changes);
+    assert.deepEqual(adjusted, target);
+    helpers._configure({ strict: true });
+  })
+
+  test('array fuzz', async () => {
+
+    const a = [...Array(10).keys()].map(n => ({ id: n + 1 }));
+
+
+    for (const i of Array(40).keys()) {
+      const a1 = JSON.parse(JSON.stringify(a));
+      const a2 = JSON.parse(JSON.stringify(a));
+      function ri() {
+        return random() * a2.length | 0;
+      }
+      for (const n of Array(5).keys()) {
+        if (random() < 0.3) {
+          // randomly delete
+          a2.splice(a2[ri()], 1);
+        }
+        if (random() < 0.1) {
+          // randomly swap
+          const [x, y] = [ri(), ri()];
+          const tmp = a2[x];
+          a2[x] = a2[y];
+          a2[y] = tmp;
+        }
+        if (random() < 0.1) {
+          // randomly add
+          a2.splice(ri(), 0, { id: random() })
+        }
+      }
+
+      const a3 = patch(a1, diff(a1, a2));
+      assert.deepEqual(a3, a2);
+    }
+
+  });
 
 });
 


### PR DESCRIPTION
Diff should always terminate, even if it's errorsome.  Diff now tacks its add operations to the end of the op set, so adds can apply more cleanly after removing or shuffling items ahead of it.

Add in some array fuzzing tests, as well as some more specific test cases.